### PR TITLE
[#PCODE-0] feat: add RPC window interface for karma tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,11 +80,13 @@ var WebDriverInstance = function (baseBrowserDecorator, args, logger) {
     log.debug('Browser capabilities: ' + JSON.stringify(spec));
 
     self.driver = wd.remote(config, 'promiseChain');
+    WDIO_BROWSER = null;
     self.browser = self.driver.init(spec, function (err, sessionID, capabilities) {
       if (err) {
         log.info('Driver error: ' + err);
       } else {
         log.debug('Driver inited with session ' + sessionID + ' and ' + capabilities + ' capabilities');
+        WDIO_BROWSER = self.browser;
       }
     });
 
@@ -109,6 +111,7 @@ var WebDriverInstance = function (baseBrowserDecorator, args, logger) {
 
     self._process = {
       kill: function() {
+        WDIO_BROWSER = null;
         interval && clearInterval(interval);
         self.driver.quit(function() {
           log.info('Killed ' + spec.testName + '.');
@@ -135,7 +138,88 @@ WebDriverInstance.prototype = {
 
 WebDriverInstance.$inject = ['baseBrowserDecorator', 'args', 'logger'];
 
+
+//////////////////
+var path = require('path');
+var pattern = function(file) {
+    return {pattern: file, included: true, served: true, watched: false};
+};
+function WebDriverBind (config, logger) {
+    var log = logger.create('WebDriverBind');
+    const adapterPath = path.join(__dirname, 'lib.js');
+    log.debug('append adapter path ' + adapterPath);
+    config.files.unshift(pattern(adapterPath));
+    config.middleware = config.middleware || []
+    config.middleware.push('WebDriverMiddleware');
+    log.debug('append middleware WebDriverMiddleware');
+}
+WebDriverBind.$inject = ['config', 'logger'];
+
+var json = require('body-parser').json();
+
+var WDIO_BROWSER = null;
+
+function WebDriverMiddleware (logger) {
+    var log = logger.create('WebDriverMiddleware');
+    var previousResult = null;
+
+    return function ActualWebDriverMiddleware (request, response, next) {
+        if (/\/\$wdRPC\$/.test(request.normalizedUrl)) {
+            if (!WDIO_BROWSER) {
+                log.error('WDIO RPC: NO WDIO_BROWSER BROWSER');
+                next(new ReferenceError('WDIO RPC: NO WDIO_BROWSER BROWSER'));
+                return;
+            }
+            json(request, response, function () {
+                var data = request.body;
+                // { method: STR, args: ARR }
+                var method = data.method;
+                var args;
+                try {
+                    args = JSON.parse(data.args);
+                } catch (e) {
+                    log.error('WDIO RPC: Error due parsing args: ' + data.args);
+                    next(e);
+                    return;
+                }
+                if (!Array.isArray(args)) {
+                    args = [args];
+                }
+                args = args.map(function (arg) {
+                    return arg === '$INDEX_PREV$' ? previousResult : arg;
+                });
+                if (method in WDIO_BROWSER) {
+                    const argsWithCallback = [].concat(args).concat(function (err, operationResponse) {
+                        previousResult = operationResponse;
+                        log.debug(`WD RPC CALL ${method} WITH GOT ERR ${err} AND RESULT ${operationResponse} DONE`);
+                        if (err) {
+                            next(err);
+                            return;
+                        }
+                        var result;
+                        try {
+                            result = JSON.stringify({ result: operationResponse });
+                        } catch (e) {
+                            result = JSON.stringify({ result: '[ native value ]' });
+                        }
+                        response.end(result);
+                    });
+                    log.debug(`WD RPC CALL ${method} WITH ${args} WAIT FOR RESULT`);
+                    WDIO_BROWSER[method].apply(WDIO_BROWSER, argsWithCallback);
+                } else {
+                    next(new ReferenceError('WDIO RPC: NO METHOD  => ' + method));
+                }
+            });
+        } else {
+            next();
+        }
+    };
+}
+WebDriverMiddleware.$inject = ['logger'];
+
 // PUBLISH DI MODULE
 module.exports = {
-  'launcher:WebDriver': ['type', WebDriverInstance]
+  'launcher:WebDriver': ['type', WebDriverInstance],
+  'framework:WebDriverBind': ['factory', WebDriverBind],
+  'middleware:WebDriverMiddleware': ['factory', WebDriverMiddleware],
 };

--- a/lib.d.ts
+++ b/lib.d.ts
@@ -1,0 +1,6 @@
+export type WebDriverWindow = {
+    /** See https://github.com/admc/wd for full list */
+    invokeWD: (string, args: Array<any>) => Promise<any>,
+    /** invoke function within native click stack */
+    withTrustedClick: (callback: VoidFunction) => void;
+}

--- a/lib.js
+++ b/lib.js
@@ -1,0 +1,65 @@
+(function (window) {
+    /**
+     * See https://github.com/admc/wd for full list
+     * */
+    window.invokeWD = function invokeWD (browserMethodName, args) {
+        if (!browserMethodName || typeof browserMethodName !== 'string') {
+            throw new ReferenceError('WD RPC: browserMethodName should be a string');
+        }
+        if (!args || !Array.isArray(args)) {
+            throw new ReferenceError('WD RPC: args should be an array');
+        }
+        return new Promise(function (resolve, reject) {
+            const xhr = new XMLHttpRequest();
+            xhr.open("POST", '/$wdRPC$');
+            xhr.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
+            xhr.onreadystatechange = function() {
+                if (this.readyState !== XMLHttpRequest.DONE) {
+                    return;
+                }
+                if (this.status !== 200) {
+                    reject(response);
+                }
+                var response;
+                try {
+                    response = JSON.parse(this.response);
+                } catch (e) {
+                    reject(e);
+                }
+                resolve(response.result);
+            }
+            xhr.send(JSON.stringify({ method: browserMethodName, args: JSON.stringify(args) }));
+        });
+    };
+    ///
+    /**
+     * Impressed with chrome test api
+     * https://github.com/chromium/chromium/blob/77578ccb4082ae20a9326d9e673225f1189ebb63/third_party/blink/web_tests/external/wpt/fullscreen/trusted-click.js#L1-L17
+     * https://github.com/chromium/chromium/blob/77578ccb4082ae20a9326d9e673225f1189ebb63/third_party/blink/web_tests/fullscreen/full-screen-prefixed-and-unprefixed.html#L23
+     * */
+    window.withTrustedClick = function (callback) {
+        var buttonId = 'invokeWD-withTrustedClick-' + window.withTrustedClick.idCounter++;
+        var button = document.createElement("button");
+        button.textContent = "click to continue test";
+        button.style.display = "block";
+        button.style.fontSize = "20px";
+        button.style.padding = "10px";
+
+        var mostTopWindow = window;
+        while (mostTopWindow.top !== mostTopWindow) mostTopWindow = mostTopWindow.top;
+        var container = mostTopWindow.document.body;
+
+        button.onclick = function invokeWD_withTrustedClick_handler () {
+            container.removeChild(button);
+            callback();
+        };
+        button.id = buttonId;
+        container.appendChild(button);
+
+        return window.invokeWD('elementById', [buttonId]).then(function () {
+            return window.invokeWD('click', [window.invokeWD.ARG_PREV]);
+        });
+    }
+    window.withTrustedClick.idCounter = 0;
+    ///
+})(window);


### PR DESCRIPTION
example with mocha-typescript

```ts
@suite
export class TestSuite {
    @test
    public async 'invoke wd' () {
        await window.invokeWD('title', []); // invoke browser.title() and return result

        await window.withTrustedClick(function () {
            alert('we have trusted click stack trace here');
        });
    }
}

```